### PR TITLE
The return_to page TLD needs to match

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ const program = new Command();
     const amazon = {
         lang: null,
         tld: options.amazonTld,
-        loginPage: `https://www.amazon.${options.amazonTld}/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fwww.amazon.de%2F%3Fref_%3Dnav_signin&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=deflex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&`,
+        loginPage: `https://www.amazon.${options.amazonTld}/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fwww.amazon.${options.amazonTld}%2F%3Fref_%3Dnav_signin&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=deflex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&`,
         orderPage: `https://www.amazon.${options.amazonTld}/gp/css/order-history`
     };
 


### PR DESCRIPTION
If we're specifying a configurable TLD then the return page needs to be for that TLD too.